### PR TITLE
Fix security auth

### DIFF
--- a/documents/forOpenAPISpecification/OpenAPI_Specification_3.0.3.md
+++ b/documents/forOpenAPISpecification/OpenAPI_Specification_3.0.3.md
@@ -382,8 +382,12 @@ APIの認証方式を記載する。
   良い例；
 
   ```yaml
-  # 認証しない場合のみ個別で定義する
-  security: []
+  paths:
+    /signin:
+      post:
+        operation_id: signin
+          # 認証しない場合のみ個別で定義する
+          security: []
   ```
 
 ## components
@@ -712,9 +716,10 @@ components:
 標準で用いるAPI認証の定義を行う。
 
 ```yaml
-# Bearer トークによる認証
-securitySchemes:
-    BearerAuth:
+components:
+  securitySchemes:
+    # Bearer トークンによる認証
+    Bearer:
       type: http
       scheme: bearer
       bearerFormat: JWT


### PR DESCRIPTION
- path配下のsecurity定義の例がわかりにくかったので、改装例を追加
- securitySchemas の階層がわかりにくかったので、components ブロックから記載するように追記
- `BearerAuth` となっていたが、他の例では `Bearer` となっており揺れていたので統一