### PR TITLE
fix: to OAS 3.0.3

### DIFF
--- a/documents/forMarkdown/future_muscle_partner/docs/04_WebAPI設計/openapi.yaml
+++ b/documents/forMarkdown/future_muscle_partner/docs/04_WebAPI設計/openapi.yaml
@@ -25,7 +25,7 @@ paths:
     post:
       tags:
         - account
-      summary: "[API01] ログインAPI"
+      summary: API-001 ログイン
       operationId: loginUser
       security: []
       requestBody:
@@ -47,7 +47,7 @@ paths:
     post:
       tags:
         - account
-      summary: "[API02] ログアウトAPI"
+      summary: API-002 ログアウト
       operationId: logoutUser
       security: []
       responses:
@@ -69,7 +69,7 @@ paths:
     post:
       tags:
         - account
-      summary: "[API03] 会員登録API"
+      summary: API-003 会員登録
       operationId: registerUser
       security: []
       requestBody:
@@ -91,7 +91,7 @@ paths:
     post:
       tags:
         - account
-      summary: "[API04] 会員退会API"
+      summary: API-004 会員退会
       operationId: signoutUser
       responses:
         '200':
@@ -108,7 +108,7 @@ paths:
     get:
       tags:
         - profile
-      summary: "[API05] 自分のプロフィール表示API"
+      summary: API-005 自分のプロフィール表示
       operationId: getUserProfile
       responses:
         '200':
@@ -123,7 +123,7 @@ paths:
     get:
       tags:
         - trainer
-      summary: "[API06] パーソナルトレーナー検索API"
+      summary: API-006 パーソナルトレーナー検索
       operationId: searchTrainers
       security: []
       responses:
@@ -139,7 +139,7 @@ paths:
     get:
       tags:
         - trainer
-      summary: "[API07] トレーニングメニュー取得API"
+      summary: API-007 トレーニングメニュー取得
       operationId: getTrainingMenu
       security: []
       parameters:
@@ -165,7 +165,7 @@ paths:
     get:
       tags:
         - trainer
-      summary: "[API08] トレーナープロフィール取得API"
+      summary: API-008 トレーナープロフィール取得
       operationId: getTrainerProfile
       security: []
       parameters:
@@ -190,7 +190,7 @@ paths:
     get:
       tags:
         - trainer
-      summary: "[API09] トレーナー口コミ取得API"
+      summary: API-009 トレーナー口コミ取得
       operationId: getTrainerReviews
       security: []
       parameters:
@@ -215,7 +215,7 @@ paths:
     get:
       tags:
         - trainer
-      summary: "[API10] トレーナースケジュール取得API"
+      summary: API-010 トレーナースケジュール取得
       operationId: getTrainerSchedule
       security: []
       parameters:
@@ -240,7 +240,7 @@ paths:
     get:
       tags:
         - booking
-      summary: "[API11] 予約済みトレーニング取得API"
+      summary: API-011 予約済みトレーニング取得
       operationId: getBookings
       responses:
         '200':
@@ -254,7 +254,7 @@ paths:
     post:
       tags:
         - booking
-      summary: "[API12] トレーニング予約API（仮登録）"
+      summary: API-012 トレーニング予約（仮登録）
       operationId: bookTraining
       requestBody:
         required: true
@@ -281,7 +281,7 @@ paths:
     delete:
       tags:
         - booking
-      summary: "[API13] トレーニング予約削除"
+      summary: API-013 トレーニング予約削除
       operationId: deleteBooking
       parameters:
         - name: bookingId
@@ -307,7 +307,7 @@ paths:
     post:
       tags:
         - booking
-      summary: "[API14] トレーニング予約API（本登録）"
+      summary: API-014 トレーニング予約（本登録）
       operationId: confirmBooking
       parameters:
         - name: bookingId
@@ -341,7 +341,7 @@ paths:
     put:
       tags:
         - booking
-      summary: "[API15] トレーニング受講ステータス変更API"
+      summary: API-015 トレーニング受講ステータス変更
       operationId: updateTrainingStatus
       parameters:
         - name: bookingId
@@ -377,7 +377,7 @@ paths:
     post:
       tags:
         - payment
-      summary: "[API16] 決済API"
+      summary: API-016 決済
       operationId: makePayment
       requestBody:
         required: true
@@ -404,7 +404,7 @@ paths:
     post:
       tags:
         - review
-      summary: "[API17] 口コミ登録"
+      summary: API-017 口コミ登録
       requestBody:
         required: true
         content:
@@ -418,7 +418,7 @@ paths:
     put:
       tags:
         - review
-      summary: "[API18] 口コミ修正"
+      summary: API-018 口コミ修正
       parameters:
         - name: reviewId
           in: path
@@ -438,7 +438,7 @@ paths:
     delete:
       tags:
         - review
-      summary: "[API19] 口コミ削除"
+      summary: API-019 口コミ削除
       parameters:
         - name: reviewId
           in: path
@@ -453,7 +453,7 @@ paths:
     post:
       tags:
         - provider
-      summary: "[API20] トレーナー登録"
+      summary: API-020 トレーナー登録
       requestBody:
         required: true
         content:
@@ -467,7 +467,7 @@ paths:
     put:
       tags:
         - provider
-      summary: "[API21]トレーナー属性更新"
+      summary: API-021 トレーナー属性更新
       requestBody:
         required: true
         content:
@@ -481,7 +481,7 @@ paths:
     post:
       tags:
         - provider
-      summary: "[API22] トレーニングメニュー登録"
+      summary: API-022 トレーニングメニュー登録
       requestBody:
         required: true
         content:
@@ -495,7 +495,7 @@ paths:
     put:
       tags:
         - provider
-      summary: "[API23] トレーニングメニュー更新"
+      summary: API-023 トレーニングメニュー更新
       parameters:
         - name: menuId
           in: path
@@ -515,7 +515,7 @@ paths:
     delete:
       tags:
         - provider
-      summary: "[API24] トレーニングメニュー削除"
+      summary: API-024 トレーニングメニュー削除
       parameters:
         - name: menuId
           in: path

--- a/documents/forMarkdown/future_muscle_partner/docs/04_WebAPI設計/openapi.yaml
+++ b/documents/forMarkdown/future_muscle_partner/docs/04_WebAPI設計/openapi.yaml
@@ -29,11 +29,7 @@ paths:
       operationId: loginUser
       security: []
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LoginRequest'
+        $ref: '#/components/requestBodies/ReqPostLoginBody'
       responses:
         '200':
           description: ログインに成功しました。
@@ -73,11 +69,7 @@ paths:
       operationId: registerUser
       security: []
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SigninRequest'
+        $ref: '#/components/requestBodies/ReqPostSigninBody'
       responses:
         '200':
           description: 会員登録に成功しました。
@@ -257,11 +249,7 @@ paths:
       summary: API-012 トレーニング予約（仮登録）
       operationId: bookTraining
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/BookingRequest'
+        $ref: '#/components/requestBodies/ReqPostBookingBody'
       responses:
         '200':
           description: 予約が仮登録されました。
@@ -317,11 +305,7 @@ paths:
           schema:
             type: string
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/BookingConfirmationRequest'
+        $ref: '#/components/requestBodies/ReqPostBookingConfirmationBody'
       responses:
         '200':
           description: 予約が本登録されました。
@@ -351,11 +335,7 @@ paths:
           schema:
             type: string
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TrainingStatusUpdateRequest'
+        $ref: '#/components/requestBodies/ReqPostTrainingStatusUpdateBody'
       responses:
         '200':
           description: ステータスが更新されました。
@@ -380,11 +360,7 @@ paths:
       summary: API-016 決済
       operationId: makePayment
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PaymentRequest'
+        $ref: '#/components/requestBodies/ReqPostPaymentBody'
       responses:
         '200':
           description: 決済が完了しました。
@@ -406,11 +382,7 @@ paths:
         - review
       summary: API-017 口コミ登録
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Review'
+        $ref: '#/components/requestBodies/ReqPostReviewBody'
       responses:
         '200':
           description: 口コミ登録成功
@@ -455,11 +427,7 @@ paths:
         - provider
       summary: API-020 トレーナー登録
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Trainer'
+        $ref: '#/components/requestBodies/ReqPostTrainerBody'
       responses:
         '200':
           description: トレーナー登録成功
@@ -469,11 +437,7 @@ paths:
         - provider
       summary: API-021 トレーナー属性更新
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TrainerAttributes'
+        $ref: '#/components/requestBodies/ReqPostTrainerAttributesBody'
       responses:
         '200':
           description: トレーナー属性更新成功
@@ -483,11 +447,7 @@ paths:
         - provider
       summary: API-022 トレーニングメニュー登録
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TrainingMenu'
+        $ref: '#/components/requestBodies/ReqPostTrainingMenuBody'
       responses:
         '200':
           description: トレーニングメニュー登録成功
@@ -647,6 +607,67 @@ components:
           type: string
         description:
           type: string
+  requestBodies:
+    ReqPostLoginBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/LoginRequest'
+    ReqPostSigninBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SigninRequest'
+    ReqPostBookingBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/BookingRequest'
+    ReqPostPaymentBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PaymentRequest'
+    ReqPostBookingConfirmationBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/BookingConfirmationRequest'
+    ReqPostTrainingStatusUpdateBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TrainingStatusUpdateRequest'
+    ReqPostReviewBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Review'
+    ReqPostTrainerBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Trainer'
+    ReqPostTrainerAttributesBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TrainerAttributes'
+    ReqPostTrainingMenuBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TrainingMenu'
   responses:
     BadRequest:
       description: 400 Bad Request

--- a/documents/forMarkdown/future_muscle_partner/docs/04_WebAPI設計/openapi.yaml
+++ b/documents/forMarkdown/future_muscle_partner/docs/04_WebAPI設計/openapi.yaml
@@ -135,7 +135,7 @@ paths:
           $ref: '#/components/responses/InternalServer'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
-  /trainers/{trainerId}/menu:
+  /trainers/{trainer_id}/menu:
     get:
       tags:
         - trainer
@@ -143,7 +143,7 @@ paths:
       operationId: getTrainingMenu
       security: []
       parameters:
-        - name: trainerId
+        - name: trainer_id
           in: path
           description: トレーナーのID
           required: true
@@ -161,7 +161,7 @@ paths:
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
 
-  /trainers/{trainerId}/profile:
+  /trainers/{trainer_id}/profile:
     get:
       tags:
         - trainer
@@ -169,7 +169,7 @@ paths:
       operationId: getTrainerProfile
       security: []
       parameters:
-        - name: trainerId
+        - name: trainer_id
           in: path
           description: トレーナーのID
           required: true
@@ -186,7 +186,7 @@ paths:
           $ref: '#/components/responses/InternalServer'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
-  /trainers/{trainerId}/reviews:
+  /trainers/{trainer_id}/reviews:
     get:
       tags:
         - trainer
@@ -194,7 +194,7 @@ paths:
       operationId: getTrainerReviews
       security: []
       parameters:
-        - name: trainerId
+        - name: trainer_id
           in: path
           description: トレーナーのID
           required: true
@@ -211,7 +211,7 @@ paths:
           $ref: '#/components/responses/InternalServer'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
-  /trainers/{trainerId}/schedule:
+  /trainers/{trainer_id}/schedule:
     get:
       tags:
         - trainer
@@ -219,7 +219,7 @@ paths:
       operationId: getTrainerSchedule
       security: []
       parameters:
-        - name: trainerId
+        - name: trainer_id
           in: path
           description: トレーナーのID
           required: true
@@ -277,14 +277,14 @@ paths:
           $ref: '#/components/responses/InternalServer'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
-  /bookings/{bookingId}:
+  /bookings/{booking_id}:
     delete:
       tags:
         - booking
       summary: API-013 トレーニング予約削除
       operationId: deleteBooking
       parameters:
-        - name: bookingId
+        - name: booking_id
           in: path
           description: 予約ID
           required: true
@@ -303,14 +303,14 @@ paths:
           $ref: '#/components/responses/InternalServer'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
-  /bookings/{bookingId}/confirm:
+  /bookings/{booking_id}/confirm:
     post:
       tags:
         - booking
       summary: API-014 トレーニング予約（本登録）
       operationId: confirmBooking
       parameters:
-        - name: bookingId
+        - name: booking_id
           in: path
           description: 予約ID
           required: true
@@ -337,14 +337,14 @@ paths:
           $ref: '#/components/responses/InternalServer'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
-  /booking/{bookingId}/status:
+  /booking/{booking_id}/status:
     put:
       tags:
         - booking
       summary: API-015 トレーニング受講ステータス変更
       operationId: updateTrainingStatus
       parameters:
-        - name: bookingId
+        - name: booking_id
           in: path
           description: 予約ID
           required: true
@@ -414,13 +414,13 @@ paths:
       responses:
         '200':
           description: 口コミ登録成功
-  /reviews/{reviewId}:
+  /reviews/{review_id}:
     put:
       tags:
         - review
       summary: API-018 口コミ修正
       parameters:
-        - name: reviewId
+        - name: review_id
           in: path
           description: 口コミID
           required: true
@@ -440,7 +440,7 @@ paths:
         - review
       summary: API-019 口コミ削除
       parameters:
-        - name: reviewId
+        - name: review_id
           in: path
           description: 口コミID
           required: true
@@ -491,13 +491,13 @@ paths:
       responses:
         '200':
           description: トレーニングメニュー登録成功
-  /training-menu/{menuId}:
+  /training-menu/{menu_id}:
     put:
       tags:
         - provider
       summary: API-023 トレーニングメニュー更新
       parameters:
-        - name: menuId
+        - name: menu_id
           in: path
           description: メニューID
           required: true
@@ -517,7 +517,7 @@ paths:
         - provider
       summary: API-024 トレーニングメニュー削除
       parameters:
-        - name: menuId
+        - name: menu_id
           in: path
           description: メニューID
           required: true


### PR DESCRIPTION
## 概要
- summary
  - ダブルクォートの削除
  - 冗長な命名の解消：語尾のAPIを削除
  - 機能IDの修正：[]を削除、```API```と連番の間にハイフンを追加
- parameter
  - camel case -> snake case
- requestBodiesの追加
## メモ
- operationIdの記述がおかしい気がするので確認（スネークケースのへの言及がないのに良い例としてスネークケースが出ている）
  - https://future-architect.github.io/coding-standards/documents/forOpenAPISpecification/OpenAPI_Specification_3.0.3.html#paths-operationid