### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Markdownの改行を、半角スペースで行うケースがあるため

```md
- aaa  
bbb
- ccc
ddd  
```

- aaa  
bbb
- ccc
ddd  
