### PR TITLE
Slack利用ガイドライン: リダイレクトファイルを追加

### DIFF
--- a/public/documents/forSlack/index.html
+++ b/public/documents/forSlack/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting...</title>
+    <link rel="canonical" href="https://future-architect.github.io/arch-guidelines/documents/forSlack/index.html" />
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=https://future-architect.github.io/arch-guidelines/documents/forSlack/index.html" />
+  </head>
+  <body>
+    <p>Redirecting...</p>
+  </body>
+</html>

--- a/public/documents/forSlack/index.html
+++ b/public/documents/forSlack/index.html
@@ -1,10 +1,16 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <title>Redirecting...</title>
-    <link rel="canonical" href="https://future-architect.github.io/arch-guidelines/documents/forSlack/index.html" />
+    <link
+      rel="canonical"
+      href="https://future-architect.github.io/arch-guidelines/documents/forSlack/index.html"
+    />
     <meta charset="utf-8" />
-    <meta http-equiv="refresh" content="0; url=https://future-architect.github.io/arch-guidelines/documents/forSlack/index.html" />
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://future-architect.github.io/arch-guidelines/documents/forSlack/index.html"
+    />
   </head>
   <body>
     <p>Redirecting...</p>

--- a/public/documents/forSlack/slack_usage_guidelines.html
+++ b/public/documents/forSlack/slack_usage_guidelines.html
@@ -1,10 +1,16 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <title>Redirecting...</title>
-    <link rel="canonical" href="https://future-architect.github.io/arch-guidelines/documents/forSlack/slack_usage_guidelines.html" />
+    <link
+      rel="canonical"
+      href="https://future-architect.github.io/arch-guidelines/documents/forSlack/slack_usage_guidelines.html"
+    />
     <meta charset="utf-8" />
-    <meta http-equiv="refresh" content="0; url=https://future-architect.github.io/arch-guidelines/documents/forSlack/slack_usage_guidelines.html" />
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://future-architect.github.io/arch-guidelines/documents/forSlack/slack_usage_guidelines.html"
+    />
   </head>
   <body>
     <p>Redirecting...</p>

--- a/public/documents/forSlack/slack_usage_guidelines.html
+++ b/public/documents/forSlack/slack_usage_guidelines.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting...</title>
+    <link rel="canonical" href="https://future-architect.github.io/arch-guidelines/documents/forSlack/slack_usage_guidelines.html" />
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=https://future-architect.github.io/arch-guidelines/documents/forSlack/slack_usage_guidelines.html" />
+  </head>
+  <body>
+    <p>Redirecting...</p>
+  </body>
+</html>


### PR DESCRIPTION
Google検索でキャッシュが残っている関係上、過去のリンクが出てしまっているため、リダイレクトファイルを追加

![{B089DA02-5158-4F26-AB53-7074DCE198BB}](https://github.com/user-attachments/assets/ed5ff0dc-0b61-4cdf-8aba-fbbde15745c6)
